### PR TITLE
통계 수치 확인 & 그래프 바로가기 링크 수정

### DIFF
--- a/server/KoreaAPIData.py
+++ b/server/KoreaAPIData.py
@@ -60,7 +60,7 @@ def KoreaCorona(param='현황 보기'):
 사망자 %s명
 격리자 %s명
 치명률 %.2f%%""" %(currentValue[0], currentValue[1], currentValue[6],currentValue[7], # currentValue['updateTime'], currentValue['TotalCase'], currentValue['TodayCase'],currentValue['TotalRecovered'],
-    currentValue[3], currentValue[2], currentValue[4], int(currentValue[2].replace(",",""))/int(currentValue[1].replace(",",""))) # currentValue['TodayRecovered'], currentValue['TotalDeath'], currentValue['NowCase']
+    currentValue[3], currentValue[2], currentValue[4], (int(currentValue[2].replace(",",""))/int(currentValue[1].replace(",",""))*100)) # currentValue['TodayRecovered'], currentValue['TotalDeath'], currentValue['NowCase']
     print(messages)
 
     # 되묻기 질문에 대한 응답.
@@ -127,6 +127,8 @@ def update_KoreaDB():
                             apiData['NowCase'], apiData['TotalChecking'], apiData['data0_1'], apiData['TodayRecovered'])
 
     return
+
+# "현황 보기"에 대한 응답 형식
 def KoreadataSendCard(message,imageUrl):
 
     dataSend = {

--- a/server/KoreaAPIData.py
+++ b/server/KoreaAPIData.py
@@ -82,7 +82,7 @@ def KoreaCorona(param='현황 보기'):
                             {
                                 "action": "webLink",
                                 "label": "바로가기",
-                                "webLinkUrl": "http://ncov.mohw.go.kr/"
+                                "webLinkUrl": "https://kosis.kr/covid/covid_index.do" # 정부 통계청 사이트
                             }
                         ]
                         }


### PR DESCRIPTION
## 통계 수치 확인 
- 치명률 계산 수정
- 그 외의 통계 수치 모두 맞음.(확인!)

## 그래프 바로가기 링크 수정
- 그래프 바로가기: 정부 코로나 보드 -> 통계청 사이트로 수정.
 가독성 측면에서 통계청 사이트가 PC/폰 상에서 더 나음.